### PR TITLE
Fix issue with invalid cuepoint crashing app

### DIFF
--- a/advanced_example/components/Sdk.xml
+++ b/advanced_example/components/Sdk.xml
@@ -142,11 +142,15 @@
 
   sub onUserSeek(seekStartTime as Integer, seekEndTime as Integer)
     previousCuePoint = m.streamManager.getPreviousCuePoint(seekEndTime)
-    print "Previous cuepoint was ";previousCuepoint.start
-    if previousCuePoint = invalid or previousCuePoint.hasPlayed
-      print "Previous cuepoint was invalid or played"
+    if previousCuePoint = invalid
+      print "Previous cuepoint was invalid"
+      return
+    else if previousCuePoint.hasPlayed
+      print "Previous cuepoint was ";previousCuepoint.start
+      print "Previous cuepoint was played"
       return
     else
+      print "Previous cuepoint was ";previousCuepoint.start
       ' Add a second to make sure we hit the keyframe at the start of the ad
       print "Seeking to ";previousCuepoint.start+1
       m.top.video.seek = previousCuePoint.start + 1


### PR DESCRIPTION
refactors cuepoint debugging print statements to only output the previous cuepoint's start, if it exists.